### PR TITLE
fixes lightning tag redundancy

### DIFF
--- a/script.js
+++ b/script.js
@@ -50,6 +50,46 @@ function loadDefaultCSV() {
             setupEventListeners();
         });
 }
+// Function to clean up redundant "Lightning" tags from video data
+function cleanupLightningTags(videoData) {
+    // Software wallets that support Lightning transactions (keep "Lightning" tag for these)
+    const lightningWallets = new Set([
+        "BlueWallet", "Phoenix", "Zeus", "Muun", "Breez", "Blixt", "Mutiny",
+        "Wallet of Satoshi", "Zebedee", "Speed", "Joltz", "Minibits",
+        "Mercury", "Aqua", "Yeti", "Theya"
+    ]);
+    
+    // All Lightning Network category tags (excluding the generic "Lightning" tag)
+    const lightningNetworkTags = new Set([
+        "Thunderhub", "Alby", "Lightning Network Daemon (LND)", 
+        "Lightning Node Connect", "LNbits", "Ride The Lightning", 
+        "Voltage", "Core Lightning", "Bolt Ring", "Boltz", "Pool", "Loop"
+    ]);
+    
+    return videoData.map(video => {
+        // Create a copy of the video object
+        const updatedVideo = { ...video };
+        
+        // Check if video has "Lightning" tag
+        if (video.tags.includes("Lightning")) {
+            // Check if video has any other Lightning Network tags
+            const hasOtherLightningTags = video.tags.some(tag => lightningNetworkTags.has(tag));
+            
+            // Check if video is about a software wallet that supports Lightning
+            const isLightningWallet = video.tags.some(tag => lightningWallets.has(tag));
+            
+            // Remove "Lightning" tag if:
+            // 1. It has other Lightning Network tags AND
+            // 2. It's NOT specifically about a Lightning-supporting software wallet
+            if (hasOtherLightningTags && !isLightningWallet) {
+                updatedVideo.tags = video.tags.filter(tag => tag !== "Lightning");
+                console.log(`Removed redundant "Lightning" tag from: ${video.title}`);
+            }
+        }
+        
+        return updatedVideo;
+    });
+}
 
 // Populate filter dropdowns
 function populateFilters() {
@@ -287,8 +327,11 @@ function parseCSV(csvContent) {
             videos.push(video);
         }
     }
-    return videos;
+    
+    // Apply Lightning tag cleanup before returning
+    return cleanupLightningTags(videos);
 }
+
 
 // Parse a single CSV line handling quoted values
 function parseCSVLine(line) {


### PR DESCRIPTION
Fixes #3 
How the Solution Works
The cleanup function operates based on these rules :

Identifies Lightning-supporting software wallets: BlueWallet, Phoenix, Zeus, Muun, Breez, Blixt, Mutiny, Wallet of Satoshi, Zebedee, Speed, Joltz, Minibits, Mercury, Aqua, Yeti, and Theya

Detects redundant tags: If a video has both the generic "Lightning" tag AND any specific Lightning Network tags (like "LND", "Thunderhub", "Alby", etc.), it removes the redundant "Lightning" tag

Preserves important tags: Keeps the "Lightning" tag for software wallets that specifically support Lightning transactions, as this indicates their Lightning capability

Example Scenarios
Video with tags: ["Thunderhub", "Lightning", "Bitcoin Core"] → Result: ["Thunderhub", "Bitcoin Core"] (Lightning removed as redundant)

Video with tags: ["BlueWallet", "Lightning", "Mobile"] → Result: ["BlueWallet", "Lightning", "Mobile"] (Lightning kept for wallet functionality)

Video with tags: ["Lightning", "Payments"] → Result: ["Lightning", "Payments"] (Lightning kept as it's the only Lightning-related tag)

The solution automatically processes your CSV data during loading, ensuring clean and non-redundant tagging while maintaining semantic meaning for Lightning-capable wallets.